### PR TITLE
Update README to add missing parameter and new date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ var amplitude = new Amplitude({
 });
 
 var params = {
-  start: '2012-05-01T02',
-  end: '2012-05-02T03'
+  //Date in yyyymmdd format
+  start: '20160726',
+  end: '20160825',
 };
 
-amplitude.export.export(params, function(err, res) {
+//Second parameter is a path to where the api response will be stored 
+amplitude.export.export(params, "temp/export_response", function(err, res) {
   // handle err and response
   ...
 });

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 0.10.33
+    version: 4.5.0
 dependencies:
   pre:
     - npm install

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sdk"
   ],
   "engines": {
-    "node": ">=0.10.30"
+    "node": ">=4.5.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
@@ -28,11 +28,11 @@
   },
   "devDependencies": {
     "chai": "^1.9.1",
-    "gulp-jsbeautifier": "0.0.2",
-    "gulp-eslint": "^0.1.8",
     "gulp": "^3.8.7",
     "gulp-diff": "^0.1.4",
+    "gulp-eslint": "^3.0.1",
     "gulp-help": "^0.1.11",
+    "gulp-jsbeautifier": "0.0.2",
     "gulp-mocha": "^1.1.0",
     "gulp-util": "^3.0.1",
     "minimist": "^0.2.0",


### PR DESCRIPTION
Amplitude API now expects dates in yyyymmdd format, I've updated the README to reflect this but perhaps the library should expect Javascript Date objects and then format the strings to abstract this detail from the library user?

Also the 2nd parameter tmpFile was not in the README
